### PR TITLE
Ignored datastore id validation for attached disk

### DIFF
--- a/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
+++ b/vsphere/internal/virtualdevice/virtual_machine_disk_subresource.go
@@ -34,7 +34,7 @@ future releases. To transition existing disks, rename the "name" attribute to
 
 Note that "label" does not control the name of a VMDK and does not need to bear
 the name of one on new disks or virtual machines. For more information, see the
-documentation for the label attribute at: 
+documentation for the label attribute at:
 
 https://www.terraform.io/docs/providers/vsphere/r/virtual_machine.html#label
 `
@@ -1444,8 +1444,6 @@ func (r *DiskSubresource) DiffGeneral() error {
 
 	if r.Get("attach").(bool) {
 		switch {
-		case r.Get("datastore_id").(string) == "":
-			return fmt.Errorf("datastore_id for disk %q is required when attach is set", name)
 		case r.Get("size").(int) > 0:
 			return fmt.Errorf("size for disk %q cannot be defined when attach is set", name)
 		case r.Get("eagerly_scrub").(bool):


### PR DESCRIPTION
- Suppressed check for datastore id
This blocks NAS datastore use in DR runbook as the datastore and VM using that datastore are in the same plan. Terraform fails to query id of newly created datasource and hence the `datastore_id` is set to empty string.