### PR TITLE
Added compatibility_version in VM resource

### DIFF
--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -276,6 +276,12 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "The UUID of the virtual machine. Also exposed as the ID of the resource.",
 		},
+		"compatibility_version": {
+			Type:        schema.TypeString,
+			Optional:    true,
+			Default:     "vmx-14",
+			Description: "The hardware compatibility version of the VM.",
+		},
 	}
 	structure.MergeSchema(s, schemaVirtualMachineResourceAllocation())
 	return s
@@ -784,6 +790,7 @@ func expandVirtualMachineConfigSpec(d *schema.ResourceData, client *govmomi.Clie
 		NestedHVEnabled:              getBoolWithRestart(d, "nested_hv_enabled"),
 		VPMCEnabled:                  getBoolWithRestart(d, "cpu_performance_counters_enabled"),
 		LatencySensitivity:           expandLatencySensitivity(d),
+		Version:                      getWithRestart(d, "compatibility_version").(string),
 	}
 
 	return obj, nil
@@ -810,6 +817,7 @@ func flattenVirtualMachineConfigInfo(d *schema.ResourceData, obj *types.VirtualM
 	d.Set("cpu_performance_counters_enabled", obj.VPMCEnabled)
 	d.Set("change_version", obj.ChangeVersion)
 	d.Set("uuid", obj.Uuid)
+	d.Set("compatibility_version", obj.Version)
 
 	if err := flattenToolsConfigInfo(d, obj.Tools); err != nil {
 		return err


### PR DESCRIPTION
To support hardware version compatibility.

### ENG-94072
**We should retain virtual machine compatibility while performing DR similar to what we do in normal recovery**