### PR TITLE
Added support for error message in VM resource

### DIFF
--- a/vsphere/virtual_machine_config_structure.go
+++ b/vsphere/virtual_machine_config_structure.go
@@ -287,6 +287,11 @@ func schemaVirtualMachineConfigSpec() map[string]*schema.Schema {
 			Computed:    true,
 			Description: "The instance UUID of the virtual machine. Uniquily identifies a virtual machine.",
 		},
+		"error_message": {
+			Type:        schema.TypeString,
+			Computed:    true,
+			Description: "Error while creating/updating this resource.",
+		},
 	}
 	structure.MergeSchema(s, schemaVirtualMachineResourceAllocation())
 	return s


### PR DESCRIPTION
### Description

Added error_message computed member in `vsphere_virtual_machine` resource. Set this if there is any error during VM creation or update.

This is required to identify what was resource specific error from terraform state. Terraform core doesn't include this error information in state file currently.