### PR TITLE
Changes to wait for the ip when customizing the VM

### DIFF
--- a/vsphere/internal/vmworkflow/virtual_machine_customize_subresource.go
+++ b/vsphere/internal/vmworkflow/virtual_machine_customize_subresource.go
@@ -3,6 +3,7 @@ package vmworkflow
 import (
 	"errors"
 	"fmt"
+	"log"
 	"net"
 	"regexp"
 
@@ -451,6 +452,23 @@ func expandCustomizationIPSettings(d *schema.ResourceData, n int, v4gwAdd, v6gwA
 	obj.DnsDomain = d.Get(netifKey("dns_domain", n, prefix)).(string)
 	obj.IpV6Spec, v6gwFound = expandCustomizationIPSettingsIPV6AddressSpec(d, n, v6gwAdd, prefix)
 	return obj, v4gwFound, v6gwFound
+}
+
+// Returns the ipv4 address provided in the customize block.
+func GetCustomIPFromSpec(d *schema.ResourceData, prefix string) string {
+	log.Print("[DEBUG] fetching ip address.")
+	s := d.Get(prefix + cKeyPrefix + "." + "network_interface").([]interface{})
+	if len(s) < 1 {
+		return ""
+	}
+
+	v4addr, v4addrOk := d.GetOk(netifKey("ipv4_address", 0, prefix))
+	if v4addrOk {
+		log.Printf("[DEBUG] Found v4addrok: true. Returning address %s", v4addr.(string))
+		return v4addr.(string)
+	}
+
+	return ""
 }
 
 // expandSliceOfCustomizationAdapterMapping reads certain ResourceData keys and

--- a/vsphere/resource_vsphere_virtual_machine.go
+++ b/vsphere/resource_vsphere_virtual_machine.go
@@ -275,16 +275,16 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 
 	// Tag the VM
 	if tagsClient != nil {
-        if err := processTagDiff(tagsClient, d, vm); err != nil {
-		    return setErrorInResource(d, err)
-	    }
+		if err := processTagDiff(tagsClient, d, vm); err != nil {
+			return setErrorInResource(d, err)
+		}
 	}
 
 	// Set custom attributes
 	if attrsProcessor != nil {
-        if err := attrsProcessor.ProcessDiff(vm); err != nil {
-		    return setErrorInResource(d, err)
-	    }
+		if err := attrsProcessor.ProcessDiff(vm); err != nil {
+			return setErrorInResource(d, err)
+		}
 	}
 
 	// The host attribute of CreateVM_Task seems to be ignored in vCenter 6.7.
@@ -293,24 +293,31 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 	// ResourceData.
 	vprops, err := virtualmachine.Properties(vm)
 	if err != nil {
-	    return setErrorInResource(d, err)
+		return setErrorInResource(d, err)
 	}
 
 	if hid, ok := d.GetOk("host_system_id"); hid.(string) != vprops.Runtime.Host.Reference().Value && ok {
 		err = resourceVSphereVirtualMachineRead(d, meta)
-	    if err != nil {
-		    return setErrorInResource(d, err)
-	    }
+		if err != nil {
+			return setErrorInResource(d, err)
+		}
 		// Restore the old host_system_id so we can still tell if a relocation is
 		// necessary.
 		err = d.Set("host_system_id", hid.(string))
-	    if err != nil {
-		    return setErrorInResource(d, err)
-	    }
-        if err = resourceVSphereVirtualMachineUpdateLocation(d, meta); err != nil {
-		    return setErrorInResource(d, err)
-	    }
+		if err != nil {
+			return setErrorInResource(d, err)
+		}
+		if err = resourceVSphereVirtualMachineUpdateLocation(d, meta); err != nil {
+			return setErrorInResource(d, err)
+		}
 	}
+
+	// If user has provided static ip addresses, we will wait until the VM gets
+	// that ip address. This is to avoid the case when for a brief period of time
+	// the vm reports the old ip. After a few seconds the ip gets changed to the
+	// user provided static ip.
+	// TODO(Mradul): The problem is not solved for the DHCP case.
+	ipv4Str := vmworkflow.GetCustomIPFromSpec(d, "")
 
 	// Wait for guest IP address if we have been set to wait for one
 	err = virtualmachine.WaitForGuestIP(
@@ -318,9 +325,10 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 		vm,
 		d.Get("wait_for_guest_ip_timeout").(int),
 		d.Get("ignored_guest_ips").([]interface{}),
+		ipv4Str,
 	)
 	if err != nil {
-	    return setErrorInResource(d, err)
+		return setErrorInResource(d, err)
 	}
 
 	// Wait for a routable address if we have been set to wait for one
@@ -330,20 +338,21 @@ func resourceVSphereVirtualMachineCreate(d *schema.ResourceData, meta interface{
 		d.Get("wait_for_guest_net_routable").(bool),
 		d.Get("wait_for_guest_net_timeout").(int),
 		d.Get("ignored_guest_ips").([]interface{}),
+		ipv4Str,
 	)
 	if err != nil {
-	    return setErrorInResource(d, err)
+		return setErrorInResource(d, err)
 	}
 
 	// All done!
 	log.Printf("[DEBUG] %s: Create complete", resourceVSphereVirtualMachineIDString(d))
-    err = resourceVSphereVirtualMachineRead(d, meta)
+	err = resourceVSphereVirtualMachineRead(d, meta)
 	if err != nil {
-	    return setErrorInResource(d, err)
+		return setErrorInResource(d, err)
 	}
 
-    // Clear error message in case of no error.
-    d.Set("error_message", "")
+	// Clear error message in case of no error.
+	d.Set("error_message", "")
 	return nil
 }
 
@@ -486,62 +495,62 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 	client := meta.(*VSphereClient).vimClient
 	tagsClient, err := tagsClientIfDefined(d, meta)
 	if err != nil {
-	    return setErrorInResource(d, err)
+		return setErrorInResource(d, err)
 	}
 
 	// Verify a proper vCenter before proceeding if custom attributes are defined
 	attrsProcessor, err := customattribute.GetDiffProcessorIfAttributesDefined(client, d)
 	if err != nil {
-	    return setErrorInResource(d, err)
+		return setErrorInResource(d, err)
 	}
 
 	id := d.Id()
 	vm, err := virtualmachine.FromUUID(client, id)
 	if err != nil {
-	    return setErrorInResource(d, fmt.Errorf("cannot locate virtual machine with UUID %q: %s", id, err))
+		return setErrorInResource(d, fmt.Errorf("cannot locate virtual machine with UUID %q: %s", id, err))
 	}
 
 	if d.HasChange("resource_pool_id") {
 		var rp *object.ResourcePool
 		rp, err = resourcepool.FromID(client, d.Get("resource_pool_id").(string))
-	    if err != nil {
-	        return setErrorInResource(d, err)
-	    }
+		if err != nil {
+			return setErrorInResource(d, err)
+		}
 
-        if err = resourcepool.MoveIntoResourcePool(rp, vm.Reference()); err != nil {
-	        return setErrorInResource(d, err)
-	    }
+		if err = resourcepool.MoveIntoResourcePool(rp, vm.Reference()); err != nil {
+			return setErrorInResource(d, err)
+		}
 
 		// If a VM is moved into or out of a vApp container, the VM's InventoryPath
 		// will change. This can affect steps later in the update process such as
 		// moving folders. To make sure the VM has the correct InventoryPath,
 		// refresh the VM after moving into a new resource pool.
 		vm, err = virtualmachine.FromMOID(client, vm.Reference().Value)
-	    if err != nil {
-	        return setErrorInResource(d, err)
-	    }
+		if err != nil {
+			return setErrorInResource(d, err)
+		}
 	}
 
 	// Update folder if necessary
 	if d.HasChange("folder") && !vappcontainer.IsVApp(client, d.Get("resource_pool_id").(string)) {
 		folder := d.Get("folder").(string)
-        if err := virtualmachine.MoveToFolder(client, vm, folder); err != nil {
-	        return setErrorInResource(d, fmt.Errorf("could not move virtual machine to folder %q: %s", folder, err))
+		if err := virtualmachine.MoveToFolder(client, vm, folder); err != nil {
+			return setErrorInResource(d, fmt.Errorf("could not move virtual machine to folder %q: %s", folder, err))
 		}
 	}
 
 	// Apply any pending tags
 	if tagsClient != nil {
-        if err := processTagDiff(tagsClient, d, vm); err != nil {
-	        return setErrorInResource(d, err)
-	    }
+		if err := processTagDiff(tagsClient, d, vm); err != nil {
+			return setErrorInResource(d, err)
+		}
 	}
 
 	// Update custom attributes
 	if attrsProcessor != nil {
-        if err := attrsProcessor.ProcessDiff(vm); err != nil {
-	        return setErrorInResource(d, err)
-	    }
+		if err := attrsProcessor.ProcessDiff(vm); err != nil {
+			return setErrorInResource(d, err)
+		}
 	}
 
 	// Ready to start the VM update. All changes from here, until the update
@@ -550,17 +559,17 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 
 	vprops, err := virtualmachine.Properties(vm)
 	if err != nil {
-	    return setErrorInResource(d, fmt.Errorf("error fetching VM properties: %s", err))
+		return setErrorInResource(d, fmt.Errorf("error fetching VM properties: %s", err))
 	}
 
 	spec, changed, err := expandVirtualMachineConfigSpecChanged(d, client, vprops.Config)
 	if err != nil {
-	    return setErrorInResource(d, fmt.Errorf("error in virtual machine configuration: %s", err))
+		return setErrorInResource(d, fmt.Errorf("error in virtual machine configuration: %s", err))
 	}
 
 	devices := object.VirtualDeviceList(vprops.Config.Hardware.Device)
-    if spec.DeviceChange, err = applyVirtualDevices(d, client, devices); err != nil {
-	    return setErrorInResource(d, err)
+	if spec.DeviceChange, err = applyVirtualDevices(d, client, devices); err != nil {
+		return setErrorInResource(d, err)
 	}
 
 	// Only carry out the reconfigure if we actually have a change to process.
@@ -570,9 +579,9 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 			// Attempt a graceful shutdown of this process. We wrap this in a VM helper.
 			timeout := d.Get("shutdown_wait_timeout").(int)
 			force := d.Get("force_power_off").(bool)
-            if err := virtualmachine.GracefulPowerOff(client, vm, timeout, force); err != nil {
-	            return setErrorInResource(d, fmt.Errorf("error shutting down virtual machine: %s", err))
-	        }
+			if err := virtualmachine.GracefulPowerOff(client, vm, timeout, force); err != nil {
+				return setErrorInResource(d, fmt.Errorf("error shutting down virtual machine: %s", err))
+			}
 		}
 		// Perform updates.
 		if _, ok := d.GetOk("datastore_cluster_id"); ok {
@@ -581,27 +590,28 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 			err = virtualmachine.Reconfigure(vm, spec)
 		}
 		if err != nil {
-	        return setErrorInResource(d, fmt.Errorf("error reconfiguring virtual machine: %s", err))
+			return setErrorInResource(d, fmt.Errorf("error reconfiguring virtual machine: %s", err))
 		}
 
 		// Re-fetch properties
 		vprops, err = virtualmachine.Properties(vm)
 		if err != nil {
-	        return setErrorInResource(d, fmt.Errorf("error re-fetching VM properties after update: %s", err))
+			return setErrorInResource(d, fmt.Errorf("error re-fetching VM properties after update: %s", err))
 		}
 		// Power back on the VM, and wait for network if necessary.
 		if vprops.Runtime.PowerState != types.VirtualMachinePowerStatePoweredOn {
 			if err := virtualmachine.PowerOn(vm); err != nil {
-	            return setErrorInResource(d, fmt.Errorf("error powering on virtual machine: %s", err))
+				return setErrorInResource(d, fmt.Errorf("error powering on virtual machine: %s", err))
 			}
 			err = virtualmachine.WaitForGuestIP(
 				client,
 				vm,
 				d.Get("wait_for_guest_ip_timeout").(int),
 				d.Get("ignored_guest_ips").([]interface{}),
+				"",
 			)
 			if err != nil {
-	            return setErrorInResource(d, err)
+				return setErrorInResource(d, err)
 			}
 			err = virtualmachine.WaitForGuestNet(
 				client,
@@ -609,9 +619,10 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 				d.Get("wait_for_guest_net_routable").(bool),
 				d.Get("wait_for_guest_net_timeout").(int),
 				d.Get("ignored_guest_ips").([]interface{}),
+				"",
 			)
 			if err != nil {
-	            return setErrorInResource(d, err)
+				return setErrorInResource(d, err)
 			}
 		}
 	}
@@ -623,18 +634,18 @@ func resourceVSphereVirtualMachineUpdate(d *schema.ResourceData, meta interface{
 	// need to be migrated have been deleted), proceed with vMotion if we have
 	// one pending.
 	if err := resourceVSphereVirtualMachineUpdateLocation(d, meta); err != nil {
-	    return setErrorInResource(d, fmt.Errorf("error running VM migration: %s", err))
+		return setErrorInResource(d, fmt.Errorf("error running VM migration: %s", err))
 	}
 
 	// All done with updates.
 	log.Printf("[DEBUG] %s: Update complete", resourceVSphereVirtualMachineIDString(d))
-    err = resourceVSphereVirtualMachineRead(d, meta)
+	err = resourceVSphereVirtualMachineRead(d, meta)
 	if err != nil {
-	    return setErrorInResource(d, err)
+		return setErrorInResource(d, err)
 	}
 
-    // Clear error message in case of no error.
-    d.Set("error_message", "")
+	// Clear error message in case of no error.
+	d.Set("error_message", "")
 	return nil
 }
 
@@ -1517,6 +1528,6 @@ func resourceVSphereVirtualMachineIDString(d structure.ResourceIDStringer) strin
 
 // Set error message in the resource property if there was an error creating the VM.
 func setErrorInResource(d *schema.ResourceData, err error) error {
-    d.Set("error_message", err.Error())
+	d.Set("error_message", err.Error())
 	return err
 }


### PR DESCRIPTION
When customizing a virtual machine and we have provided the static IPs during customization, we will wait until the desired IP is assigned. 

Terraform returns the first IP that is reported by VMware tools and at time that IP can be the old IP of the VM. These changes are to avoid that case and wait until the desired IP is achieved.